### PR TITLE
Added support for resolution callbacks and backreferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,31 +52,35 @@ const routes = {
   '/users/:id/posts': 'Posts by :id', // backreferences will be replaced by correspoding parts of url
   
 /* 
-  you can provide a callback, which will receive placeholder mapping as a parameter
-  for instance at /users/dummy/posts/4 the following pattern will result in callback with 
-  {':id':'dummy', ':page':'4'}
+*  you can provide a callback of (url, match)=>string signature
+*  match will contain pattern values both prefixed and isolated
+*  for instance the following pattern will result in callback with
+*   
+*  ('/users/dummy/posts/4', {
+*   'id':'dummy', ':id':'dummy', 
+*   'page':'4',   ':page':'4'
+*  })
+*  
+*  while link will contain smth like "Page 4 of 10"
+*/
+  
+  '/users/:id/posts/:page': (match)=>`Page ${match[':page']} of ${Pagination.total()}`,
+  
+   
+/*
+  For static routes 'match' argument is always null
   
   NOTE: Services or stores will not be automatically injected into resolver function, 
-  you should .bind context to resolver (better way) or  to inject them 
-  into your routes declaration, like here (bad pattern, don't do it like this)
-*/
-  '/users/:id/posts/:page': (match)=>`Page ${match[':page']} of ${Pagination.total()}`,
-
-   
-/* 
-  you can provide a callback for exact match as well,
-  it will receive the full url as callback, allowing you to use some external resolver of (url)=>string signature.
-  in this example it will receive '/settings' or '/forum' respectively 
+  you should either inject your services to your config, like in previous example (bad pattern), 
+  .bind context to your resolvers,  or even totally relay the resolution 
+  to a store-aware service
 */
   
-  '/settings': MyBreadcrumbsResolver.resolve,
-  '/forum': MyBreadcrumbsResolver.resolve 
-
+  '/settings': MyBreadcrumbsResolver.resolve, // will receive ('/settings',null)
+  '/forum': MyBreadcrumbsResolver.resolve  
 };
-
-
-
-
+  
+  
 class App extends Component {
   render() {
     return (
@@ -96,7 +100,7 @@ The routes definition object is not traversed in default object iteration order.
 * Routes with placeholders are sorted by amount of placeholders in the route, so the route with less placeholders will have priority over more "dynamic" route when resolving. For example, if you have both "**/user/new**" and "**/user/:id**" routes, the first one with always be resolved correctly despite in which order you put them into the definition object
 * Routes having the same number of placeholders will be sorted by length, so that shorter routes will take precedence over longer routes.
 
-The basic idea to understand the order in which routes are resolved to link names is to think that, if current url can be resolved to several routes, the least ambiguous definition will always be used. A constant is always prefered to a wildcard, and less wildcards are prefered to more of them.
+The basic idea to understand about the order in which routes are resolved to link names is to think that, if current url can be resolved to several routes, the least ambiguous definition will always be used. A constant is always prefered to a wildcard, and less wildcards are prefered to more of them.
 
 
 ## Custom html markup

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ const routes = {
   you should .bind context to resolver (better way) or  to inject them 
   into your routes declaration, like here (bad pattern, don't do it like this)
 */
-  '/users/:id/posts/:page': (match)=>`Page ${match[':page']} of ${Pagination.total()}`
+  '/users/:id/posts/:page': (match)=>`Page ${match[':page']} of ${Pagination.total()}`,
 
    
 /* 
@@ -71,8 +71,7 @@ const routes = {
   
   '/settings': MyBreadcrumbsResolver.resolve,
   '/forum': MyBreadcrumbsResolver.resolve 
-//  
-    
+
 };
 
 
@@ -89,6 +88,16 @@ class App extends Component {
 }
 
 ```
+
+## Match precedence order
+
+The routes definition object is not traversed in default object iteration order. Instead there's a stable sort applied to routes based on several considerations:
+* Routes without any placeholders like "**:id**" will always have top priority when resolving link name
+* Routes with placeholders are sorted by amount of placeholders in the route, so the route with less placeholders will have priority over more "dynamic" route when resolving. For example, if you have both "**/user/new**" and "**/user/:id**" routes, the first one with always be resolved correctly despite in which order you put them into the definition object
+* Routes having the same number of placeholders will be sorted by length, so that shorter routes will take precedence over longer routes.
+
+The basic idea to understand the order in which routes are resolved to link names is to think that, if current url can be resolved to several routes, the least ambiguous definition will always be used. A constant is always prefered to a wildcard, and less wildcards are prefered to more of them.
+
 
 ## Custom html markup
 

--- a/README.md
+++ b/README.md
@@ -36,16 +36,46 @@ import {
 } from 'react-router-dom'
      
 import Breadcrumbs  from 'react-router-dynamic-breadcrumbs';   
-
-// Create routes mapping
-
+  
+/**
+*  Create routes mapping
+*  
+*  All dynamic params will display automatically.
+*  not that even though '/users/:id' route is not in configuration file, 
+*  it's corresponding link it will be displayed as the value of ':id'
+*/
 const routes = {
   '/': 'Home',
-  '/blog': 'Blog',
-  '/users': 'Users'
-  '/users/:id/info': 'User Info'
-  // you don't need declare /users/:id. All dynamic params will display automatically.
+  '/blog': 'Blog', 
+  '/users': 'Users',
+  '/users/:id/info': 'User Info', 
+  '/users/:id/posts': 'Posts by :id', // backreferences will be replaced by correspoding parts of url
+  
+/* 
+  you can provide a callback, which will receive placeholder mapping as a parameter
+  for instance at /users/dummy/posts/4 the following pattern will result in callback with 
+  {':id':'dummy', ':page':'4'}
+  
+  NOTE: Services or stores will not be automatically injected into resolver function, 
+  you should .bind context to resolver (better way) or  to inject them 
+  into your routes declaration, like here (bad pattern, don't do it like this)
+*/
+  '/users/:id/posts/:page': (match)=>`Page ${match[':page']} of ${Pagination.total()}`
+
+   
+/* 
+  you can provide a callback for exact match as well,
+  it will receive the full url as callback, allowing you to use some external resolver of (url)=>string signature.
+  in this example it will receive '/settings' or '/forum' respectively 
+*/
+  
+  '/settings': MyBreadcrumbsResolver.resolve,
+  '/forum': MyBreadcrumbsResolver.resolve 
+//  
+    
 };
+
+
 
 
 class App extends Component {
@@ -83,7 +113,7 @@ class App extends Component {
 
 | Property | Type | Description
 :---|:---|:---
-| `mappedRoutes` | object | Plain javascript object with routes paths and names. Expected signature: `(Object): PropTypes.shape({}).isRequired` |
+| `mappedRoutes` | object | Plain javascript object with routes paths and names/resolver callbacks. Expected signature: `(Object): PropTypes.shape({}).isRequired` |
 | `WrapperComponent` | function | Function responsible for creating wrapper html structure. Expected signature: `(props) => <JSX>{props.children}</JSX> PropTypes.func` |
 | `ActiveLinkComponent` | function | Function responsible for creating active link html structure. Expected signature: `(props) => <JSX>{props.children}</JSX> PropTypes.func` |
 | `LinkComponent` | function | Function responsible for creating link html structure. Expected signature: `(props) => <JSX>{props.children}</JSX> PropTypes.func` |

--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ const routes = {
   to a store-aware service
 */
   
-  '/settings': MyBreadcrumbsResolver.resolve, // will receive ('/settings',null)
-  '/forum': MyBreadcrumbsResolver.resolve  
+  '/settings': MyBreadcrumbsResolver.resolve, // will receive ('/settings',null) 
 };
   
   

--- a/dist/BreadcrumbsItem.js
+++ b/dist/BreadcrumbsItem.js
@@ -34,8 +34,11 @@ var BreadcrumbsItem = function BreadcrumbsItem(props) {
     var routeMatcher = new RegExp(key.replace(placeholderMatcher, '([\\w-]+)'));
     var match = url.match(routeMatcher);
     if (!match) return null;
-    return placeholders.reduce(function (memo, placeholder, index) {
-      return Object.assign(memo, _defineProperty({}, placeholder, match[index + 1] || null));
+    return placeholders.reduce(function (memo, placeholder, index, array) {
+      var _Object$assign;
+
+      var value = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : match[index + 1] || null;
+      return Object.assign(memo, (_Object$assign = {}, _defineProperty(_Object$assign, placeholder, value), _defineProperty(_Object$assign, placeholder.substring(1), value), _Object$assign));
     }, {});
   };
 
@@ -65,7 +68,7 @@ var BreadcrumbsItem = function BreadcrumbsItem(props) {
         if (key.indexOf(':') !== -1) {
           var _match = getPlaceholderVars(url, key);
           if (_match) {
-            if (_routeName instanceof Function) fRouteName = _routeName(_match);else {
+            if (_routeName instanceof Function) fRouteName = _routeName(url, _match);else {
               fRouteName = Object.keys(_match).reduce(function (routeName, placeholder) {
                 return routeName.replace(placeholder, _match[placeholder]);
               }, _routeName);
@@ -73,7 +76,7 @@ var BreadcrumbsItem = function BreadcrumbsItem(props) {
           }
         } else {
           if (key === url) {
-            if (_routeName instanceof Function) fRouteName = _routeName(key);else fRouteName = _routeName;
+            if (_routeName instanceof Function) fRouteName = _routeName(key, null);else fRouteName = _routeName;
           }
         }
       }

--- a/dist/BreadcrumbsItem.js
+++ b/dist/BreadcrumbsItem.js
@@ -4,6 +4,8 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -16,6 +18,8 @@ var _propTypes2 = _interopRequireDefault(_propTypes);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 var BreadcrumbsItem = function BreadcrumbsItem(props) {
   var match = props.match,
       name = props.name,
@@ -24,6 +28,18 @@ var BreadcrumbsItem = function BreadcrumbsItem(props) {
       ActiveLinkComponent = _props$parentProps.ActiveLinkComponent,
       LinkComponent = _props$parentProps.LinkComponent;
 
+
+  var getPlaceholderVars = function getPlaceholderVars(url, key) {
+    var placeholderMatcher = /:[^\s/]+/g;
+    var placeholders = key.match(placeholderMatcher);
+    if (!placeholders) return null;
+    var routeMatcher = new RegExp(key.replace(placeholderMatcher, '([\\w-]+)'));
+    var match = url.match(routeMatcher);
+    if (!match) return null;
+    return placeholders.reduce(function (memo, placeholder, index) {
+      return Object.assign(memo, _defineProperty({}, placeholder, match[index + 1] || null));
+    }, {});
+  };
 
   var findRouteName = function findRouteName(url) {
     return mappedRoutes[url];
@@ -34,18 +50,35 @@ var BreadcrumbsItem = function BreadcrumbsItem(props) {
 
     for (var key in routesCollection) {
       if (routesCollection.hasOwnProperty(key)) {
-        var routeMatcher = new RegExp(key.replace(/:[^\s/]+/g, '([\\w-]+)'));
+        var _ret = function () {
+          var routeName = routesCollection[key];
+          if (key.indexOf(':') !== -1) {
+            var _match = getPlaceholderVars(url, key);
+            if (_match) {
+              if (routeName instanceof Function) fRouteName = routeName(_match);else Object.keys(_match).forEach(function (placeholder) {
+                return fRouteName = routeName.replace(placeholder, _match[placeholder]);
+              });
+            }
+          } else {
+            if (key === url) {
+              if (routeName instanceof Function) return {
+                  v: routeName(key)
+                };
+              return {
+                v: routeName
+              };
+            }
+          }
+        }();
 
-        if (url.match(routeMatcher) && key.indexOf(':') !== -1) {
-          fRouteName = routesCollection[key];
-        }
+        if ((typeof _ret === 'undefined' ? 'undefined' : _typeof(_ret)) === "object") return _ret.v;
       }
     }
 
     return fRouteName;
   };
 
-  var routeName = matchRouteName(match.url, mappedRoutes) || findRouteName(match.url) || name;
+  var routeName = matchRouteName(match.url, mappedRoutes) || name;
 
   if (routeName) {
     return match.isExact ? _react2.default.createElement(

--- a/dist/BreadcrumbsItem.js
+++ b/dist/BreadcrumbsItem.js
@@ -4,8 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
-
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -50,28 +48,24 @@ var BreadcrumbsItem = function BreadcrumbsItem(props) {
 
     for (var key in routesCollection) {
       if (routesCollection.hasOwnProperty(key)) {
-        var _ret = function () {
-          var routeName = routesCollection[key];
-          if (key.indexOf(':') !== -1) {
-            var _match = getPlaceholderVars(url, key);
-            if (_match) {
-              if (routeName instanceof Function) fRouteName = routeName(_match);else Object.keys(_match).forEach(function (placeholder) {
-                return fRouteName = routeName.replace(placeholder, _match[placeholder]);
-              });
+        var _routeName = routesCollection[key];
+        if (key.indexOf(':') !== -1) {
+          (function () {
+            var match = getPlaceholderVars(url, key);
+            if (match) {
+              if (_routeName instanceof Function) fRouteName = _routeName(match);else {
+                fRouteName = Object.keys(match).reduce(function (routeName, placeholder) {
+                  return routeName.replace(placeholder, match[placeholder]);
+                }, _routeName);
+              }
             }
-          } else {
-            if (key === url) {
-              if (routeName instanceof Function) return {
-                  v: routeName(key)
-                };
-              return {
-                v: routeName
-              };
-            }
+          })();
+        } else {
+          if (key === url) {
+            if (_routeName instanceof Function) return _routeName(key);
+            return _routeName;
           }
-        }();
-
-        if ((typeof _ret === 'undefined' ? 'undefined' : _typeof(_ret)) === "object") return _ret.v;
+        }
       }
     }
 

--- a/src/BreadcrumbsItem.js
+++ b/src/BreadcrumbsItem.js
@@ -33,9 +33,10 @@ const BreadcrumbsItem = (props) => {
           if (match) {
             if (routeName instanceof Function)
               fRouteName = routeName(match);
-            else
-              Object.keys(match)
-                    .forEach((placeholder) => fRouteName = routeName.replace(placeholder, match[ placeholder ]));
+            else {
+              fRouteName = Object.keys(match)
+                                 .reduce((routeName, placeholder) => routeName.replace(placeholder, match[ placeholder ]), routeName);
+            }
           }
         }
         else {

--- a/src/BreadcrumbsItem.js
+++ b/src/BreadcrumbsItem.js
@@ -21,8 +21,6 @@ const BreadcrumbsItem = (props) => {
     }), {});
   };
 
-  const findRouteName = url => mappedRoutes[ url ];
-
   const matchRouteName = (url, routesCollection) => {
     let fRouteName = null;
 

--- a/src/BreadcrumbsItem.js
+++ b/src/BreadcrumbsItem.js
@@ -15,8 +15,9 @@ const BreadcrumbsItem = (props) => {
     const match = url.match(routeMatcher);
     if (!match)
       return null;
-    return placeholders.reduce((memo, placeholder, index) => Object.assign(memo, {
-      [placeholder]: match[ index + 1 ] || null
+    return placeholders.reduce((memo, placeholder, index, array, value = match[ index + 1 ] || null) => Object.assign(memo, {
+      [placeholder]: value,
+      [placeholder.substring(1)]: value
     }), {});
   };
 
@@ -45,7 +46,7 @@ const BreadcrumbsItem = (props) => {
           const match = getPlaceholderVars(url, key);
           if (match) {
             if (routeName instanceof Function)
-              fRouteName = routeName(match);
+              fRouteName = routeName(url, match);
             else {
               fRouteName = Object.keys(match)
                                  .reduce((routeName, placeholder) => routeName.replace(placeholder, match[ placeholder ]), routeName);
@@ -55,7 +56,7 @@ const BreadcrumbsItem = (props) => {
         else {
           if (key === url) {
             if (routeName instanceof Function)
-              fRouteName = routeName(key);
+              fRouteName = routeName(url, null);
             else
               fRouteName = routeName;
           }


### PR DESCRIPTION
So this is a pretty major change, which I had to make to use this component to its full extent at my projects.  See the new readme to get a whole idea of what I did, it's still backwards compatible I guess

tl;dr: 
1) route mapping can now have functions instead of strings, which should return the display name of a link in the breadcrumbs chain
2) strings in route mapping can contain backreferences which will be replaced
3) made some algorithm optimizations, removed additional dereferencing functions, since we're iterating the whole mapping object anyways
4) most exact matching pattern will be used when looking for route name in the route map

feel free to set a new version in package.json if you feel like, or to rewrite my clumsy examples in readme :)