### PR TITLE
fixed a bug with url resolution to behave as described

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ const routes = {
 *  while link will contain smth like "Page 4 of 10"
 */
   
-  '/users/:id/posts/:page': (match)=>`Page ${match[':page']} of ${Pagination.total()}`,
+  '/users/:id/posts/:page': (url, match)=>`Page ${match[':page']} of ${Pagination.total()}`,
   
    
 /*

--- a/dist/BreadcrumbsItem.js
+++ b/dist/BreadcrumbsItem.js
@@ -31,7 +31,7 @@ var BreadcrumbsItem = function BreadcrumbsItem(props) {
   var getPlaceholderVars = function getPlaceholderVars(url, key) {
     var placeholders = key.match(placeholderMatcher);
     if (!placeholders) return null;
-    var routeMatcher = new RegExp(key.replace(placeholderMatcher, '([\\w-]+)'));
+    var routeMatcher = new RegExp('^' + key.replace(placeholderMatcher, '([\\w-]+)') + '$');
     var match = url.match(routeMatcher);
     if (!match) return null;
     return placeholders.reduce(function (memo, placeholder, index, array) {
@@ -40,10 +40,6 @@ var BreadcrumbsItem = function BreadcrumbsItem(props) {
       var value = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : match[index + 1] || null;
       return Object.assign(memo, (_Object$assign = {}, _defineProperty(_Object$assign, placeholder, value), _defineProperty(_Object$assign, placeholder.substring(1), value), _Object$assign));
     }, {});
-  };
-
-  var findRouteName = function findRouteName(url) {
-    return mappedRoutes[url];
   };
 
   var matchRouteName = function matchRouteName(url, routesCollection) {
@@ -55,10 +51,6 @@ var BreadcrumbsItem = function BreadcrumbsItem(props) {
       switch (true) {
         case aTokenCount === bTokenCount:
           return a.length > b.length ? 1 : -1; //longest routes have the priority
-        case aTokenCount === 0 && bTokenCount !== 0:
-          return 1;
-        case aTokenCount !== 0 && bTokenCount === 0:
-          return -1; //static routes always have the priority over dynamic
         default:
           return aTokenCount < bTokenCount ? 1 : -1; //among dynamic routes the one with less placeholders take priority
       }
@@ -76,7 +68,7 @@ var BreadcrumbsItem = function BreadcrumbsItem(props) {
           }
         } else {
           if (key === url) {
-            if (_routeName instanceof Function) fRouteName = _routeName(key, null);else fRouteName = _routeName;
+            if (_routeName instanceof Function) fRouteName = _routeName(url, null);else fRouteName = _routeName;
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router-dynamic-breadcrumbs",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Breadcrumbs react component for react-router-v4",
   "main": "dist/index.js",
   "scripts": {

--- a/src/BreadcrumbsItem.js
+++ b/src/BreadcrumbsItem.js
@@ -11,7 +11,7 @@ const BreadcrumbsItem = (props) => {
     const placeholders = key.match(placeholderMatcher);
     if (!placeholders)
       return null;
-    const routeMatcher = new RegExp(key.replace(placeholderMatcher, '([\\w-]+)'));
+    const routeMatcher = new RegExp('^' + key.replace(placeholderMatcher, '([\\w-]+)') + '$');
     const match = url.match(routeMatcher);
     if (!match)
       return null;
@@ -30,10 +30,6 @@ const BreadcrumbsItem = (props) => {
       switch (true) {
         case aTokenCount === bTokenCount:
           return a.length > b.length ? 1 : -1; //longest routes have the priority
-        case aTokenCount === 0 && bTokenCount !== 0:
-          return 1;
-        case aTokenCount !== 0 && bTokenCount === 0:
-          return -1; //static routes always have the priority over dynamic
         default:
           return aTokenCount < bTokenCount ? 1 : -1; //among dynamic routes the one with less placeholders take priority
       }


### PR DESCRIPTION
there was untraced mistake about building matching RegExp without string termination, which caused particular routes without a wildcard not to have priority over longer one with wildcard, i.e.
_/users/:user_id/posts_ should not have priority over /users/:user_id/posts/:post_id, which it does in current version.

Other changes are just a bit of optimization