### PR TITLE
Change react to be a peer dependency rather than a normal dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
   "homepage": "https://github.com/roya3000/react-router-dynamic-breadcrumbs#readme",
   "dependencies": {
     "prop-types": "^15.5.10",
-    "react": "^15.6.1",
     "react-router-dom": "^4.1.1"
+  },
+  "peerDependencies": {
+    "react": "^15.6.1"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
React expects to be a singleton on the page. The proper way to express this as a library author is with `peerDependencies`, otherwise you run the risk of pulling in multiple copies of React. In particular, upgrading to React 16 in one's application will cause `react-router-dynamic-breadcrumbs` to get its own copy of React 15, which causes all sorts of problems.

See e.g. [react-select's package.json](https://github.com/JedWatson/react-select/blob/82910d9225f7aff73ac5052da9dc1e7f52f13de7/package.json#L78) for an example of another library doing this.